### PR TITLE
Cria a função de interpretação para medidade de test coverage

### DIFF
--- a/src/core/interpretation_functions.py
+++ b/src/core/interpretation_functions.py
@@ -4,6 +4,10 @@ import numpy as np
 
 
 def check_arguments(data_frame):
+    """
+    Raises an InvalidInterpretationFunctionArguments exception if argument it's not a pandas.DataFrame.
+    """
+
     if not isinstance(data_frame, pd.DataFrame):
         raise InvalidInterpretationFunctionArguments(
             "Expected data_frame to be a pandas.DataFrame"
@@ -11,6 +15,10 @@ def check_arguments(data_frame):
 
 
 def check_number_of_files(number_of_files):
+    """
+    Raises an InvalidMetricValue exception if the number of files is lesser or equal than 0.
+    """
+
     if number_of_files <= 0:
         raise InvalidMetricValue("The number of files is lesser or equal than 0")
 
@@ -37,9 +45,9 @@ def create_coordinate_pair(min_threshhold, max_threshold):
 
 def non_complex_files_density(data_frame):
     """
-    Calculates non-complex files density (m1).
+    Calculates non-complex files density (em1).
 
-    This function calculates non-complex files density measure (m1)
+    This function calculates non-complex files density measure (em1)
     used to assess the changeability quality subcharacteristic.
     """
 
@@ -49,7 +57,7 @@ def non_complex_files_density(data_frame):
     files_complexity = data_frame["complexity"].astype(float)
     # files_functions = m2 metric
     files_functions = data_frame["functions"].astype(float)
-    # number_of_files = m3 metric
+    # number_of_files = Tm3 metric
     number_of_files = len(data_frame)
 
     check_number_of_files(number_of_files)
@@ -64,7 +72,6 @@ def non_complex_files_density(data_frame):
             "The number of functions of all files is lesser or equal than 0"
         )
 
-    # m0 =
     m0 = np.median(files_complexity / files_functions)
 
     x, y = create_coordinate_pair(0, m0)
@@ -78,9 +85,9 @@ def non_complex_files_density(data_frame):
 
 def commented_files_density(data_frame):
     """
-    Calculates commented files density (m2).
+    Calculates commented files density (em2).
 
-    This function calculates commented files density measure (m2)
+    This function calculates commented files density measure (em2)
     used to assess the changeability quality subcharacteristic.
     """
 
@@ -89,12 +96,10 @@ def commented_files_density(data_frame):
 
     check_arguments(data_frame)
 
-    # number_of_files = m3 metric
+    # number_of_files = Tm3 metric
     number_of_files = len(data_frame)
     # files_comment_lines_density = m4 metric
-    files_comment_lines_density = data_frame["comment_lines_density"].astype(
-        float
-    )  # m4
+    files_comment_lines_density = data_frame["comment_lines_density"].astype(float)
 
     check_number_of_files(number_of_files)
 
@@ -122,9 +127,9 @@ def commented_files_density(data_frame):
 
 def absence_of_duplications(data_frame):
     """
-    Calculates duplicated files absence (m3).
+    Calculates duplicated files absence (em3).
 
-    This function calculates the duplicated files absence measure (m3)
+    This function calculates the duplicated files absence measure (em3)
     used to assess the changeability quality subcharacteristic.
     """
 
@@ -136,7 +141,7 @@ def absence_of_duplications(data_frame):
     files_duplicated_lines_density = data_frame["duplicated_lines_density"].astype(
         float
     )
-    # number_of_files = m3 metric
+    # number_of_files = Tm3 metric
     number_of_files = len(data_frame)
 
     check_number_of_files(number_of_files)
@@ -152,6 +157,6 @@ def absence_of_duplications(data_frame):
         files_duplicated_lines_density < DUPLICATED_LINES_THRESHOLD
     ]
 
-    em2i = interpolate_series(files_below_threshold, x, y)
+    em3i = interpolate_series(files_below_threshold, x, y)
 
-    return np.sum(em2i) / number_of_files
+    return np.sum(em3i) / number_of_files

--- a/src/core/interpretation_functions.py
+++ b/src/core/interpretation_functions.py
@@ -154,7 +154,7 @@ def absence_of_duplications(data_frame):
     x, y = create_coordinate_pair(0, DUPLICATED_LINES_THRESHOLD / 100)
 
     files_below_threshold = files_duplicated_lines_density[
-        files_duplicated_lines_density < DUPLICATED_LINES_THRESHOLD
+        files_duplicated_lines_density <= DUPLICATED_LINES_THRESHOLD
     ]
 
     em3i = interpolate_series(files_below_threshold, x, y)

--- a/src/core/interpretation_functions.py
+++ b/src/core/interpretation_functions.py
@@ -160,3 +160,40 @@ def absence_of_duplications(data_frame):
     em3i = interpolate_series(files_below_threshold, x, y)
 
     return np.sum(em3i) / number_of_files
+
+
+def test_coverage(data_frame):
+    """
+    Calculates test coverage (em6).
+
+    This function calculates the test coverage measure (em6)
+    used to assess the testing status subcharacteristic.
+    """
+
+    MINIMUM_COVERAGE_THRESHOLD = 60
+    MAXIMUM_COVERAGE_THRESHOLD = 90
+
+    check_arguments(data_frame)
+
+    # number_of_files = m3 metric
+    number_of_files = len(data_frame)
+    # test_coverage = m6 metric
+    test_coverage = data_frame["coverage"].astype(float)
+
+    check_number_of_files(number_of_files)
+
+    x, y = create_coordinate_pair(
+        MINIMUM_COVERAGE_THRESHOLD / 100, MAXIMUM_COVERAGE_THRESHOLD / 100
+    )
+
+    files_between_thresholds = test_coverage[
+        test_coverage.between(
+            MINIMUM_COVERAGE_THRESHOLD,
+            MAXIMUM_COVERAGE_THRESHOLD,
+            inclusive="both",
+        )
+    ]
+
+    em6i = interpolate_series(files_between_thresholds, x, y)
+
+    return np.sum(em6i) / number_of_files

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -72,7 +72,7 @@ def generate_file_dataframe_per_release(metric_list, json, language_extension):
     return df
 
 
-def create_file_df(json_list):
+def create_file_df(json_list, language_extension="js"):
 
     df = pd.DataFrame()
 
@@ -83,7 +83,7 @@ def create_file_df(json_list):
         file_component_data = metric_per_file(file_component)
 
         file_component_df = generate_file_dataframe_per_release(
-            METRICS_LIST, file_component_data, language_extension="js"
+            METRICS_LIST, file_component_data, language_extension=language_extension
         )
 
         file_component_df["filename"] = os.path.basename(i)

--- a/tests/unit/data/between_zero_and_one_coverage.json
+++ b/tests/unit/data/between_zero_and_one_coverage.json
@@ -1,0 +1,1087 @@
+{
+    "paging": {
+        "pageIndex": 1,
+        "pageSize": 500,
+        "total": 21
+    },
+    "baseComponent": {
+        "id": "AXvcoGVC6PVVEaJzOiXa",
+        "key": "fga-eps-mds_2021.1-Oraculo-Profile",
+        "name": "2021.1-Oraculo-Profile",
+        "qualifier": "TRK",
+        "measures": [
+            {
+                "metric": "duplicated_lines_density",
+                "value": "0.0",
+                "bestValue": true
+            },
+            {
+                "metric": "functions",
+                "value": "25"
+            },
+            {
+                "metric": "security_rating",
+                "value": "1.0",
+                "bestValue": true
+            },
+            {
+                "metric": "files",
+                "value": "12"
+            },
+            {
+                "metric": "complexity",
+                "value": "0"
+            },
+            {
+                "metric": "ncloc",
+                "value": "351"
+            },
+            {
+                "metric": "coverage",
+                "value": "10.2",
+                "bestValue": false
+            },
+            {
+                "metric": "reliability_rating",
+                "value": "1.0",
+                "bestValue": true
+            },
+            {
+                "metric": "comment_lines_density",
+                "value": "0.8",
+                "bestValue": false
+            }
+        ]
+    },
+    "components": [
+        {
+            "id": "AXwhGkCozqq0kU_3AE-r",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Database/config",
+            "name": "config",
+            "qualifier": "DIR",
+            "path": "src/Database/config",
+            "measures": [
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "functions",
+                    "value": "0"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "2"
+                },
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "15"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "15.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "6.3",
+                    "bestValue": false
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-q",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Database/config/config.json",
+            "name": "config.json",
+            "qualifier": "FIL",
+            "path": "src/Database/config/config.json",
+            "language": "json",
+            "measures": [
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-4",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Controller",
+            "name": "Controller",
+            "qualifier": "DIR",
+            "path": "src/Controller",
+            "measures": [
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "functions",
+                    "value": "6"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "141"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "15.3",
+                    "bestValue": false
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "1.4",
+                    "bestValue": false
+                }
+            ]
+        },
+        {
+            "id": "AXwvtbh3DoMJqJkANfci",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:tests/create-admin.js",
+            "name": "create-admin.js",
+            "qualifier": "UTS",
+            "path": "tests/create-admin.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-t",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Database",
+            "name": "Database",
+            "qualifier": "DIR",
+            "path": "src/Database",
+            "measures": [
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "functions",
+                    "value": "6"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "3"
+                },
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "50"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "100.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "2.0",
+                    "bestValue": false
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-p",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Database/config/database.js",
+            "name": "database.js",
+            "qualifier": "FIL",
+            "path": "src/Database/config/database.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "15"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "15.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "6.3",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-z",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Model/Department.js",
+            "name": "Department.js",
+            "qualifier": "FIL",
+            "path": "src/Model/Department.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "2"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "22"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "100.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-u",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Utils/hash.js",
+            "name": "hash.js",
+            "qualifier": "FIL",
+            "path": "src/Utils/hash.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "1"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "6"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "20.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-o",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/index.js",
+            "name": "index.js",
+            "qualifier": "FIL",
+            "path": "src/index.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "2"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "25"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "95.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-s",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Database/index.js",
+            "name": "index.js",
+            "qualifier": "FIL",
+            "path": "src/Database/index.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "6"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "35"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "13.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXvcoOKcggjSG_Di9QHT",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:tests/index.test.js",
+            "name": "index.test.js",
+            "qualifier": "UTS",
+            "path": "tests/index.test.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-v",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Utils/JWT.js",
+            "name": "JWT.js",
+            "qualifier": "FIL",
+            "path": "src/Utils/JWT.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "2"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "19"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "13.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-0",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Model/Level.js",
+            "name": "Level.js",
+            "qualifier": "FIL",
+            "path": "src/Model/Level.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "2"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "22"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "16.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-1",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Model",
+            "name": "Model",
+            "qualifier": "DIR",
+            "path": "src/Model",
+            "measures": [
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "functions",
+                    "value": "8"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "4"
+                },
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "100"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "12.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-2",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/routes.js",
+            "name": "routes.js",
+            "qualifier": "FIL",
+            "path": "src/routes.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "10"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "100.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-x",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Model/Section.js",
+            "name": "Section.js",
+            "qualifier": "FIL",
+            "path": "src/Model/Section.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "2"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "22"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "100.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-5",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src",
+            "name": "src",
+            "qualifier": "DIR",
+            "path": "src",
+            "measures": [
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "functions",
+                    "value": "25"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "12"
+                },
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "351"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "95.2",
+                    "bestValue": false
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.8",
+                    "bestValue": false
+                }
+            ]
+        },
+        {
+            "id": "AXvcoOKcggjSG_Di9QHU",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:tests",
+            "name": "tests",
+            "qualifier": "DIR",
+            "path": "tests",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-y",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Model/User.js",
+            "name": "User.js",
+            "qualifier": "FIL",
+            "path": "src/Model/User.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "2"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "34"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "100.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-3",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Controller/UserController.js",
+            "name": "UserController.js",
+            "qualifier": "FIL",
+            "path": "src/Controller/UserController.js",
+            "language": "js",
+            "measures": [
+                {
+                    "metric": "functions",
+                    "value": "6"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "141"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "91.3",
+                    "bestValue": false
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "1.4",
+                    "bestValue": false
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_success_density",
+                    "value": "100.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AXwhGkCozqq0kU_3AE-w",
+            "key": "fga-eps-mds_2021.1-Oraculo-Profile:src/Utils",
+            "name": "Utils",
+            "qualifier": "DIR",
+            "path": "src/Utils",
+            "measures": [
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "functions",
+                    "value": "3"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "2"
+                },
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "25"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "100.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "reliability_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                }
+            ]
+        }
+    ]
+}

--- a/tests/unit/test_interpretation_functions.py
+++ b/tests/unit/test_interpretation_functions.py
@@ -40,6 +40,11 @@ INVALID_METRICS_TEST_DATA = [
         "tests/unit/data/zero_number_of_files.json",
         "The number of files is lesser or equal than 0",
     ),
+    (
+        test_coverage,
+        "tests/unit/data/zero_number_of_files.json",
+        "The number of files is lesser or equal than 0",
+    ),
 ]
 
 
@@ -124,6 +129,12 @@ INVALID_ARGUMENTS_TEST_DATA = [
     (absence_of_duplications, False),
     (
         absence_of_duplications,
+        pd.Series(data={"a": 1, "b": 2, "c": 3}, index=["a", "b", "c"]),
+    ),
+    (test_coverage, None),
+    (test_coverage, False),
+    (
+        test_coverage,
         pd.Series(data={"a": 1, "b": 2, "c": 3}, index=["a", "b", "c"]),
     ),
 ]

--- a/tests/unit/test_interpretation_functions.py
+++ b/tests/unit/test_interpretation_functions.py
@@ -2,6 +2,7 @@ from src.core.interpretation_functions import (
     non_complex_files_density,
     commented_files_density,
     absence_of_duplications,
+    test_coverage,
 )
 from src.core.exceptions import (
     InvalidMetricValue,
@@ -88,6 +89,21 @@ SUCCESS_TEST_DATA = [
         "tests/unit/data/fga-eps-mds-2020_2-Lend.it-Raleway-user-13-04-2021.json",
         1.0,
     ),
+    (
+        test_coverage,
+        "tests/unit/data/fga-eps-mds_2021-2-SiGeD-Frontend-03-15-2022-23_57_08.json",
+        0.0,
+    ),
+    (
+        test_coverage,
+        "tests/unit/data/between_zero_and_one_coverage.json",
+        0.545454,
+    ),
+    (
+        test_coverage,
+        "tests/unit/data/zero_cyclomatic_complexity.json",
+        1.0,
+    ),
 ]
 
 
@@ -149,6 +165,7 @@ def test_interpretation_functions_success(
     Test cases in which the interpretation functions should return a valid measure
     """
 
+    # assert expected_result == 1.0
     json = glob(file_path)
 
     result = interpretation_func(create_file_df(json))


### PR DESCRIPTION
## Descrição
Cria a função de interpretação para medidade de test coverage.

[Criar a função para a medida test coverage](https://github.com/fga-eps-mds/2021-2-MeasureSoftGram-Doc/issues/151)

## Porque este Pull Request é necessário?
Para que seja possível calcular a medidade de test coverage.

## Critérios de aceitação
- [ ] Garantir que as métricas são validas e não nulas
- [ ] Garantir que os valores de referência estejam definidos
- [ ] O resultado da interpolação numérica deve pertencer ao intervalo [a,b]={x∈ℝ:0≤x≤1}
- [ ] Deve realizar a operação de forma equivalente ao código abaixo:

```py
def m6(df):
    m3 = len(df) # total files
    m6 = df['coverage'].astype(float)
    #  intervals for em6 thresholds
    x = np.array([0.6, 0.9])
    y = np.array([0, 1])
    # Intervals for ma3 interpretation
    em6i = []
    for if6i in m6:
        if  if6i >= 60:
            em6i.append(np.interp(if6i/100,x, y))
        else:
            em6i.append(0)
    em6 = np.sum(em6i)/m3
    return em6
```

Closes #https://github.com/fga-eps-mds/2021-2-MeasureSoftGram-Doc/issues/151
