### PR TITLE
Alterando a estrutura da constante das pré configurações salvas

### DIFF
--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -30,42 +30,37 @@ AVAILABLE_PRE_CONFIGS = {
             "name": "Passed Tests",
             "subcharacteristics": ["testing_status"],
             "characteristics": ["reliability"],
+            "metrics": ["test_success_density"],
         },
         "test_builds": {
             "name": "Test Builds",
             "subcharacteristics": ["testing_status"],
             "characteristics": ["reliability"],
+            "metrics": ["tests", "test_execution_time"],
         },
         "test_coverage": {
             "name": "Test Coverage",
             "subcharacteristics": ["testing_status"],
             "characteristics": ["reliability"],
-            "metrics": ["coverage"]
+            "metrics": ["coverage"],
         },
         "non_complex_file_density": {
             "name": "Non complex file density",
             "subcharacteristics": ["modifiability"],
             "characteristics": ["maintainability"],
-            "metrics": [
-                "complexity",
-                "functions"
-            ]
+            "metrics": ["complexity", "functions"],
         },
         "commented_file_density": {
             "name": "Commented file density",
             "subcharacteristics": ["modifiability"],
             "characteristics": ["maintainability"],
-            "metrics": [
-                "comment_lines_density"
-            ]
+            "metrics": ["comment_lines_density"],
         },
         "duplication_absense": {
             "name": "Duplication abscense",
             "subcharacteristics": ["modifiability"],
             "characteristics": ["maintainability"],
-            "metrics": [
-                "duplicated_lines_density"
-            ]
+            "metrics": ["duplicated_lines_density"],
         },
-    }
+    },
 }

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -1,32 +1,3 @@
-""" AVAILABLE_PRE_CONFIGS = {
-    "reliability": {
-        "name": "Reliability",
-        "subcharacteristics": {
-            "testing_status": {
-                "name": "Testing Status",
-                "measures": {
-                    "passed_tests": {"name": "Passed Tests"},
-                    "test_builds": {"name": "Test Builds"},
-                    "test_coverage": {"name": "Test Coverage"},
-                },
-            }
-        },
-    },
-    "maintainability": {
-        "name": "Maintainability",
-        "subcharacteristics": {
-            "modifiability": {
-                "name": "Modifiability",
-                "measures": {
-                    "non_complex_file_density": {"name": "Non complex file density"},
-                    "commented_file_density": {"name": "Commented file density"},
-                    "duplication_absense": {"name": "Duplication abscense"},
-                },
-            }
-        },
-    },
-} """
-
 AVAILABLE_PRE_CONFIGS = {
     "characteristics": {
         "reliability": {
@@ -69,21 +40,32 @@ AVAILABLE_PRE_CONFIGS = {
             "name": "Test Coverage",
             "subcharacteristics": ["testing_status"],
             "characteristics": ["reliability"],
+            "metrics": ["coverage"]
         },
         "non_complex_file_density": {
             "name": "Non complex file density",
             "subcharacteristics": ["modifiability"],
             "characteristics": ["maintainability"],
+            "metrics": [
+                "complexity",
+                "functions"
+            ]
         },
         "commented_file_density": {
             "name": "Commented file density",
             "subcharacteristics": ["modifiability"],
             "characteristics": ["maintainability"],
+            "metrics": [
+                "comment_lines_density"
+            ]
         },
         "duplication_absense": {
             "name": "Duplication abscense",
             "subcharacteristics": ["modifiability"],
             "characteristics": ["maintainability"],
+            "metrics": [
+                "duplicated_lines_density"
+            ]
         },
-    },
+    }
 }


### PR DESCRIPTION
# Alterar o formato da Pré Configuração

## Descrição
Muda o formato da Pré Configuração para armazenar todas as métricas necessárias

[Ler as métricas do arquivo](https://github.com/fga-eps-mds/2021-2-measuresoftgram-doc/issues/56)

## Porque este Pull Request é necessário?
Para que o MeasureSoftgram seja capaz de validar as métricas que chegarão com as métricas requeridas na pré configuração escolhida pelo usuário

## Critérios de aceitação

- [ ] Somente arquivos .json são válidos
- [ ] Poder selecionar no sistema de arquivos o arquivo desejado
- [ ] O sistema deve informar erro se o arquivo não existir ou não puder ser aberto
- [ ] O sistema deve informar se o JSON lido não é no formato sonar
- [ ] O sistema deve validar as métricas recebidas com as métricas esperadas para a pré configuração do modelo e informar erro caso se preciso
- [ ] O sistema deve validar se as métricas estão em formato numérico (NaN), não nulo e informado erro
- [ ] O arquivo json deve ter uma chave de baseComponent
- [ ] Receber um ID de pré-configuração válido
- [ ] Exibir mensagem de aviso no caso de sucesso ou de erro


Closes #56
