### PR TITLE
Validação de Métricas vindas do Sonar

### DIFF
--- a/tests/integration/test_analysis.py
+++ b/tests/integration/test_analysis.py
@@ -54,11 +54,11 @@ def test_analysis_sucess():
 
         assert response.status_code == 200
         assert response.json["characteristics"] == {
-            "maintainability": 0.5,
+            "maintainability": 0.6666666666666665,
             "reliability": 0.7142857142857143,
         }
         assert response.json["subcharacteristics"] == {
-            "modifiability": 0.5,
+            "modifiability": 0.6666666666666665,
             "testing_status": 0.7142857142857143,
         }
-        assert response.json["sqc"] == {"sqc": 0.6165241607725739}
+        assert response.json["sqc"] == {"sqc": 0.6908865775498528}

--- a/tests/unit/data/invalid_commented_lines_density.json
+++ b/tests/unit/data/invalid_commented_lines_density.json
@@ -1,0 +1,1053 @@
+{
+    "paging": {
+        "pageIndex": 1,
+        "pageSize": 500,
+        "total": 25
+    },
+    "baseComponent": {
+        "id": "AX9FgyLHNIj_v_uQK41e",
+        "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI",
+        "name": "2021-2-MeasureSoftGram-CLI",
+        "qualifier": "TRK",
+        "measures": [
+            {
+                "metric": "duplicated_lines_density",
+                "value": "0.0",
+                "bestValue": true
+            },
+            {
+                "metric": "functions",
+                "value": "31"
+            },
+            {
+                "metric": "test_execution_time",
+                "value": "1596"
+            },
+            {
+                "metric": "test_failures",
+                "value": "0",
+                "bestValue": true
+            },
+            {
+                "metric": "test_errors",
+                "value": "0",
+                "bestValue": true
+            },
+            {
+                "metric": "security_rating",
+                "value": "1.0",
+                "bestValue": true
+            },
+            {
+                "metric": "tests",
+                "value": "37"
+            },
+            {
+                "metric": "files",
+                "value": "7"
+            },
+            {
+                "metric": "complexity",
+                "value": "63"
+            },
+            {
+                "metric": "ncloc",
+                "value": "386"
+            },
+            {
+                "metric": "coverage",
+                "value": "77.6",
+                "bestValue": false
+            },
+            {
+                "metric": "comment_lines_density",
+                "value": "2.5",
+                "bestValue": false
+            }
+        ]
+    },
+    "components": [
+        {
+            "id": "AX9GDsKlZuVL7NjXSAZ4",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "UTS",
+            "path": "tests/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX-gLz5MkGDeAMJwS_WD",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "UTS",
+            "path": "tests/integration/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX-gLz5MkGDeAMJwS_WH",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "UTS",
+            "path": "tests/unit/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsd",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/system/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "UTS",
+            "path": "tests/system/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsZ",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "FIL",
+            "path": "src/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "0"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsW",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "FIL",
+            "path": "src/cli/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "0"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsY",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli",
+            "name": "cli",
+            "qualifier": "DIR",
+            "path": "src/cli",
+            "measures": [
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "functions",
+                    "value": "31"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "6"
+                },
+                {
+                    "metric": "complexity",
+                    "value": "63"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "386"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "77.6",
+                    "bestValue": false
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "2.5",
+                    "bestValue": false
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsV",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/cliRunner.py",
+            "name": "cliRunner.py",
+            "qualifier": "FIL",
+            "path": "src/cli/cliRunner.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "6"
+                },
+                {
+                    "metric": "functions",
+                    "value": "5"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "86"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "68.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": null,
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsU",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/create.py",
+            "name": "create.py",
+            "qualifier": "FIL",
+            "path": "src/cli/create.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "37"
+                },
+                {
+                    "metric": "functions",
+                    "value": "21"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "179"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "90.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX-iRCWviOmgBqQJPMII",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/create_test.py",
+            "name": "create_test.py",
+            "qualifier": "UTS",
+            "path": "tests/unit/create_test.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "34"
+                },
+                {
+                    "metric": "tests",
+                    "value": "23"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsh",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/data",
+            "name": "data",
+            "qualifier": "DIR",
+            "path": "tests/unit/data",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsT",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/exceptions.py",
+            "name": "exceptions.py",
+            "qualifier": "FIL",
+            "path": "src/cli/exceptions.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "16"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "100.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "33.3",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX-gLz5MkGDeAMJwS_WE",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration",
+            "name": "integration",
+            "qualifier": "DIR",
+            "path": "tests/integration",
+            "measures": [
+                {
+                    "metric": "test_execution_time",
+                    "value": "7"
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "tests",
+                    "value": "1"
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsS",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/jsonReader.py",
+            "name": "jsonReader.py",
+            "qualifier": "FIL",
+            "path": "src/cli/jsonReader.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "19"
+                },
+                {
+                    "metric": "functions",
+                    "value": "5"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "74"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "77.5",
+                    "bestValue": false
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsX",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/parser.py",
+            "name": "parser.py",
+            "qualifier": "FIL",
+            "path": "src/cli/parser.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "1"
+                },
+                {
+                    "metric": "functions",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "31"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsg",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/data/sonar.json",
+            "name": "sonar.json",
+            "qualifier": "UTS",
+            "path": "tests/unit/data/sonar.json",
+            "language": "json",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsa",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src",
+            "name": "src",
+            "qualifier": "DIR",
+            "path": "src",
+            "measures": [
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "functions",
+                    "value": "31"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "7"
+                },
+                {
+                    "metric": "complexity",
+                    "value": "63"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "386"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "77.6",
+                    "bestValue": false
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "2.5",
+                    "bestValue": false
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsf",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/system",
+            "name": "system",
+            "qualifier": "DIR",
+            "path": "tests/system",
+            "measures": [
+                {
+                    "metric": "test_execution_time",
+                    "value": "1543"
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "tests",
+                    "value": "2"
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsc",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/system/test_help.py",
+            "name": "test_help.py",
+            "qualifier": "UTS",
+            "path": "tests/system/test_help.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "512"
+                },
+                {
+                    "metric": "tests",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX-gLz5MkGDeAMJwS_WJ",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/test_jsonReader.py",
+            "name": "test_jsonReader.py",
+            "qualifier": "UTS",
+            "path": "tests/unit/test_jsonReader.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "12"
+                },
+                {
+                    "metric": "tests",
+                    "value": "11"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsb",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/system/test_no_env.py",
+            "name": "test_no_env.py",
+            "qualifier": "UTS",
+            "path": "tests/system/test_no_env.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "523"
+                },
+                {
+                    "metric": "tests",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsi",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration/test_sigint.py",
+            "name": "test_sigint.py",
+            "qualifier": "UTS",
+            "path": "tests/integration/test_sigint.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "7"
+                },
+                {
+                    "metric": "tests",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfse",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/system/test_sigint.py",
+            "name": "test_sigint.py",
+            "qualifier": "UTS",
+            "path": "tests/system/test_sigint.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "508"
+                },
+                {
+                    "metric": "tests",
+                    "value": "0"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX9GDsKlZuVL7NjXSAZ5",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests",
+            "name": "tests",
+            "qualifier": "DIR",
+            "path": "tests",
+            "measures": [
+                {
+                    "metric": "test_execution_time",
+                    "value": "1596"
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "tests",
+                    "value": "37"
+                }
+            ]
+        },
+        {
+            "id": "AX-gLz5MkGDeAMJwS_WK",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit",
+            "name": "unit",
+            "qualifier": "DIR",
+            "path": "tests/unit",
+            "measures": [
+                {
+                    "metric": "test_execution_time",
+                    "value": "46"
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "tests",
+                    "value": "34"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/unit/data/invalid_complexity_value.json
+++ b/tests/unit/data/invalid_complexity_value.json
@@ -1,0 +1,1053 @@
+{
+    "paging": {
+        "pageIndex": 1,
+        "pageSize": 500,
+        "total": 25
+    },
+    "baseComponent": {
+        "id": "AX9FgyLHNIj_v_uQK41e",
+        "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI",
+        "name": "2021-2-MeasureSoftGram-CLI",
+        "qualifier": "TRK",
+        "measures": [
+            {
+                "metric": "duplicated_lines_density",
+                "value": "0.0",
+                "bestValue": true
+            },
+            {
+                "metric": "functions",
+                "value": "31"
+            },
+            {
+                "metric": "test_execution_time",
+                "value": "1596"
+            },
+            {
+                "metric": "test_failures",
+                "value": "0",
+                "bestValue": true
+            },
+            {
+                "metric": "test_errors",
+                "value": "0",
+                "bestValue": true
+            },
+            {
+                "metric": "security_rating",
+                "value": "1.0",
+                "bestValue": true
+            },
+            {
+                "metric": "tests",
+                "value": "37"
+            },
+            {
+                "metric": "files",
+                "value": "7"
+            },
+            {
+                "metric": "complexity",
+                "value": "63"
+            },
+            {
+                "metric": "ncloc",
+                "value": "386"
+            },
+            {
+                "metric": "coverage",
+                "value": "77.6",
+                "bestValue": false
+            },
+            {
+                "metric": "comment_lines_density",
+                "value": "2.5",
+                "bestValue": false
+            }
+        ]
+    },
+    "components": [
+        {
+            "id": "AX9GDsKlZuVL7NjXSAZ4",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "UTS",
+            "path": "tests/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX-gLz5MkGDeAMJwS_WD",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "UTS",
+            "path": "tests/integration/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX-gLz5MkGDeAMJwS_WH",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "UTS",
+            "path": "tests/unit/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsd",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/system/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "UTS",
+            "path": "tests/system/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsZ",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "FIL",
+            "path": "src/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "0"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsW",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/__init__.py",
+            "name": "__init__.py",
+            "qualifier": "FIL",
+            "path": "src/cli/__init__.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": null
+                },
+                {
+                    "metric": "functions",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "0"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsY",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli",
+            "name": "cli",
+            "qualifier": "DIR",
+            "path": "src/cli",
+            "measures": [
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "functions",
+                    "value": "31"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "6"
+                },
+                {
+                    "metric": "complexity",
+                    "value": "63"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "386"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "77.6",
+                    "bestValue": false
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "2.5",
+                    "bestValue": false
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsV",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/cliRunner.py",
+            "name": "cliRunner.py",
+            "qualifier": "FIL",
+            "path": "src/cli/cliRunner.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "6"
+                },
+                {
+                    "metric": "functions",
+                    "value": "5"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "86"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "68.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "2.3",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsU",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/create.py",
+            "name": "create.py",
+            "qualifier": "FIL",
+            "path": "src/cli/create.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "37"
+                },
+                {
+                    "metric": "functions",
+                    "value": "21"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "179"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "90.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX-iRCWviOmgBqQJPMII",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/create_test.py",
+            "name": "create_test.py",
+            "qualifier": "UTS",
+            "path": "tests/unit/create_test.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "34"
+                },
+                {
+                    "metric": "tests",
+                    "value": "23"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsh",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/data",
+            "name": "data",
+            "qualifier": "DIR",
+            "path": "tests/unit/data",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsT",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/exceptions.py",
+            "name": "exceptions.py",
+            "qualifier": "FIL",
+            "path": "src/cli/exceptions.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "0"
+                },
+                {
+                    "metric": "functions",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "16"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "100.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "33.3",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX-gLz5MkGDeAMJwS_WE",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration",
+            "name": "integration",
+            "qualifier": "DIR",
+            "path": "tests/integration",
+            "measures": [
+                {
+                    "metric": "test_execution_time",
+                    "value": "7"
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "tests",
+                    "value": "1"
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsS",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/jsonReader.py",
+            "name": "jsonReader.py",
+            "qualifier": "FIL",
+            "path": "src/cli/jsonReader.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "19"
+                },
+                {
+                    "metric": "functions",
+                    "value": "5"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "74"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "77.5",
+                    "bestValue": false
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsX",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src/cli/parser.py",
+            "name": "parser.py",
+            "qualifier": "FIL",
+            "path": "src/cli/parser.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "complexity",
+                    "value": "1"
+                },
+                {
+                    "metric": "functions",
+                    "value": "0"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "31"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "0.0",
+                    "bestValue": false
+                },
+                {
+                    "metric": "files",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsg",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/data/sonar.json",
+            "name": "sonar.json",
+            "qualifier": "UTS",
+            "path": "tests/unit/data/sonar.json",
+            "language": "json",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsa",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:src",
+            "name": "src",
+            "qualifier": "DIR",
+            "path": "src",
+            "measures": [
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "functions",
+                    "value": "31"
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "files",
+                    "value": "7"
+                },
+                {
+                    "metric": "complexity",
+                    "value": "63"
+                },
+                {
+                    "metric": "ncloc",
+                    "value": "386"
+                },
+                {
+                    "metric": "coverage",
+                    "value": "77.6",
+                    "bestValue": false
+                },
+                {
+                    "metric": "comment_lines_density",
+                    "value": "2.5",
+                    "bestValue": false
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsf",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/system",
+            "name": "system",
+            "qualifier": "DIR",
+            "path": "tests/system",
+            "measures": [
+                {
+                    "metric": "test_execution_time",
+                    "value": "1543"
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "tests",
+                    "value": "2"
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsc",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/system/test_help.py",
+            "name": "test_help.py",
+            "qualifier": "UTS",
+            "path": "tests/system/test_help.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "512"
+                },
+                {
+                    "metric": "tests",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX-gLz5MkGDeAMJwS_WJ",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/test_jsonReader.py",
+            "name": "test_jsonReader.py",
+            "qualifier": "UTS",
+            "path": "tests/unit/test_jsonReader.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "12"
+                },
+                {
+                    "metric": "tests",
+                    "value": "11"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsb",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/system/test_no_env.py",
+            "name": "test_no_env.py",
+            "qualifier": "UTS",
+            "path": "tests/system/test_no_env.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "523"
+                },
+                {
+                    "metric": "tests",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfsi",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration/test_sigint.py",
+            "name": "test_sigint.py",
+            "qualifier": "UTS",
+            "path": "tests/integration/test_sigint.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "7"
+                },
+                {
+                    "metric": "tests",
+                    "value": "1"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AYAetRFpTtMNDnZRXfse",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/system/test_sigint.py",
+            "name": "test_sigint.py",
+            "qualifier": "UTS",
+            "path": "tests/system/test_sigint.py",
+            "language": "py",
+            "measures": [
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_execution_time",
+                    "value": "508"
+                },
+                {
+                    "metric": "tests",
+                    "value": "0"
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "duplicated_lines_density",
+                    "value": "0.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                }
+            ]
+        },
+        {
+            "id": "AX9GDsKlZuVL7NjXSAZ5",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests",
+            "name": "tests",
+            "qualifier": "DIR",
+            "path": "tests",
+            "measures": [
+                {
+                    "metric": "test_execution_time",
+                    "value": "1596"
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "tests",
+                    "value": "37"
+                }
+            ]
+        },
+        {
+            "id": "AX-gLz5MkGDeAMJwS_WK",
+            "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit",
+            "name": "unit",
+            "qualifier": "DIR",
+            "path": "tests/unit",
+            "measures": [
+                {
+                    "metric": "test_execution_time",
+                    "value": "46"
+                },
+                {
+                    "metric": "test_failures",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "test_errors",
+                    "value": "0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "security_rating",
+                    "value": "1.0",
+                    "bestValue": true
+                },
+                {
+                    "metric": "tests",
+                    "value": "34"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/unit/data/invalid_complexity_value.json
+++ b/tests/unit/data/invalid_complexity_value.json
@@ -243,7 +243,7 @@
             "measures": [
                 {
                     "metric": "complexity",
-                    "value": null
+                    "value": "0"
                 },
                 {
                     "metric": "functions",
@@ -334,7 +334,7 @@
             "measures": [
                 {
                     "metric": "complexity",
-                    "value": "6"
+                    "value": null
                 },
                 {
                     "metric": "functions",

--- a/tests/unit/data/zero_number_of_files.json
+++ b/tests/unit/data/zero_number_of_files.json
@@ -1,269 +1,70 @@
 {
-  "paging":{
-      "pageIndex":1,
-      "pageSize":100,
-      "total":5
-  },
-  "baseComponent":{
-      "id":"AX9FgyLHNIj_v_uQK41e",
-      "key":"fga-eps-mds_2021-2-MeasureSoftGram-CLI",
-      "name":"2021-2-MeasureSoftGram-CLI",
-      "qualifier":"TRK",
-      "measures":[
-          {
-              "metric":"duplicated_lines_density",
-              "value":"0.0",
-              "bestValue":true
-          },
-          {
-              "metric":"functions",
-              "value":"2"
-          },
-          {
-              "metric":"test_execution_time",
-              "value":"2"
-          },
-          {
-              "metric":"test_failures",
-              "value":"0",
-              "bestValue":true
-          },
-          {
-              "metric":"test_errors",
-              "value":"0",
-              "bestValue":true
-          },
-          {
-              "metric":"security_rating",
-              "value":"1.0",
-              "bestValue":true
-          },
-          {
-              "metric":"tests",
-              "value":"2"
-          },
-          {
-              "metric":"files","value":"0"
-          },
-          {
-              "metric":"complexity",
-              "value":"2"
-          },
-          {
-              "metric":"ncloc",
-              "value":"4"
-          },
-          {
-              "metric":"coverage",
-              "value":"100.0",
-              "bestValue":true
-          },
-          {
-              "metric":"comment_lines_density",
-              "value":"20.0",
-              "bestValue":false
-          }
-      ]
-  },
-  "components":[
-      {
-          "id":"AX9GDsKlZuVL7NjXSAZ4",
-          "key":"fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/__init__.py",
-          "name":"__init__.py",
-          "qualifier":"UTS",
-          "path":"tests/__init__.py",
-          "language":"py",
-          "measures":[
-              {
-                  "metric":"security_rating",
-                  "value":"1.0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"test_errors",
-                  "value":"0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"duplicated_lines_density",
-                  "value":"0.0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"test_failures",
-                  "value":"0",
-                  "bestValue":true
-              }
-          ]
-      },
-      {
-          "id":"AX9Fg6R0WRlRH47OejaP",
-          "key":"fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/cli.py",
-          "name":"cli.py",
-          "qualifier":"FIL",
-          "path":"measuresoftgram/cli.py",
-          "language":"py",
-          "measures":[
-              {
-                  "metric":"complexity",
-                  "value":"2"
-              },
-              {
-                  "metric":"functions",
-                  "value":"2"
-              },
-              {
-                  "metric":"ncloc",
-                  "value":"4"
-              },
-              {
-                  "metric":"coverage",
-                  "value":"100.0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"security_rating",
-                  "value":"1.0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"comment_lines_density",
-                  "value":"20.0",
-                  "bestValue":false
-              },
-              {
-                  "metric":"files","value":"0"
-              },
-              {
-                  "metric":"test_errors",
-                  "value":"0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"duplicated_lines_density",
-                  "value":"0.0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"test_failures",
-                  "value":"0",
-                  "bestValue":true
-              }
-          ]
-      },
-      {
-          "id":"AX9GDsKlZuVL7NjXSAZ3",
-          "key":"fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/hello_world_test.py",
-          "name":"hello_world_test.py",
-          "qualifier":"UTS",
-          "path":"tests/hello_world_test.py",
-          "language":"py",
-          "measures":[
-              {
-                  "metric":"security_rating",
-                  "value":"1.0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"test_execution_time",
-                  "value":"2"
-              },
-              {
-                  "metric":"tests",
-                  "value":"2"
-              },
-              {
-                  "metric":"test_errors",
-                  "value":"0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"duplicated_lines_density",
-                  "value":"0.0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"test_failures",
-                  "value":"0",
-                  "bestValue":true
-              }
-          ]
-      },
-      {
-          "id":"AX9Fg6R0WRlRH47OejaQ",
-          "key":"fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram",
-          "name":"measuresoftgram",
-          "qualifier":"DIR",
-          "path":"measuresoftgram",
-          "measures":[
-              {
-                  "metric":"duplicated_lines_density",
-                  "value":"0.0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"functions",
-                  "value":"2"
-              },
-              {
-                  "metric":"security_rating",
-                  "value":"1.0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"files","value":"0"
-              },
-              {
-                  "metric":"complexity",
-                  "value":"2"
-              },
-              {
-                  "metric":"ncloc",
-                  "value":"4"
-              },
-              {
-                  "metric":"coverage",
-                  "value":"100.0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"comment_lines_density",
-                  "value":"20.0",
-                  "bestValue":false
-              }
-          ]
-      },
-      {
-          "id":"AX9GDsKlZuVL7NjXSAZ5",
-          "key":"fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests",
-          "name":"tests",
-          "qualifier":"DIR",
-          "path":"tests",
-          "measures":[
-              {
-                  "metric":"test_execution_time",
-                  "value":"2"
-              },
-              {
-                  "metric":"test_failures",
-                  "value":"0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"test_errors",
-                  "value":"0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"security_rating",
-                  "value":"1.0",
-                  "bestValue":true
-              },
-              {
-                  "metric":"tests",
-                  "value":"2"
-              }
-          ]
-      }
-  ]
+    "paging": {
+        "pageIndex": 1,
+        "pageSize": 100,
+        "total": 5
+    },
+    "baseComponent": {
+        "id": "AX9FgyLHNIj_v_uQK41e",
+        "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI",
+        "name": "2021-2-MeasureSoftGram-CLI",
+        "qualifier": "TRK",
+        "measures": [
+            {
+                "metric": "duplicated_lines_density",
+                "value": "0.0",
+                "bestValue": true
+            },
+            {
+                "metric": "functions",
+                "value": "2"
+            },
+            {
+                "metric": "test_execution_time",
+                "value": "2"
+            },
+            {
+                "metric": "test_failures",
+                "value": "0",
+                "bestValue": true
+            },
+            {
+                "metric": "test_errors",
+                "value": "0",
+                "bestValue": true
+            },
+            {
+                "metric": "security_rating",
+                "value": "1.0",
+                "bestValue": true
+            },
+            {
+                "metric": "tests",
+                "value": "2"
+            },
+            {
+                "metric": "files",
+                "value": "0"
+            },
+            {
+                "metric": "complexity",
+                "value": "2"
+            },
+            {
+                "metric": "ncloc",
+                "value": "4"
+            },
+            {
+                "metric": "coverage",
+                "value": "100.0",
+                "bestValue": true
+            },
+            {
+                "metric": "comment_lines_density",
+                "value": "20.0",
+                "bestValue": false
+            }
+        ]
+    },
+    "components": []
 }

--- a/tests/unit/test_analysis.py
+++ b/tests/unit/test_analysis.py
@@ -23,7 +23,7 @@ def test_calculate_measures():
 
     expected_measures = {
         "test_builds": 0.0010166666666666666,
-        "test_coverage": 0.5647222222222222,
+        "test_coverage": 0.752962962962963,
         "passed_tests": 0.7142857142857143,
     }
 

--- a/tests/unit/test_interpretation_functions.py
+++ b/tests/unit/test_interpretation_functions.py
@@ -22,31 +22,49 @@ INVALID_METRICS_TEST_DATA = [
         non_complex_files_density,
         "tests/unit/data/zero_number_of_files.json",
         "The number of files is lesser or equal than 0",
+        "py",
     ),
     (
         non_complex_files_density,
         "tests/unit/data/zero_number_of_functions.json",
         "The number of functions of all files is lesser or equal than 0",
+        "js",
     ),
     (
         non_complex_files_density,
         "tests/unit/data/zero_cyclomatic_complexity.json",
         "The cyclomatic complexity of all files is lesser or equal than 0",
+        "js",
     ),
     (
         commented_files_density,
         "tests/unit/data/zero_number_of_files.json",
         "The number of files is lesser or equal than 0",
+        "py",
     ),
     (
         absence_of_duplications,
         "tests/unit/data/zero_number_of_files.json",
         "The number of files is lesser or equal than 0",
+        "py",
     ),
     (
         interpret_test_coverage,
         "tests/unit/data/zero_number_of_files.json",
         "The number of files is lesser or equal than 0",
+        "py",
+    ),
+    (
+        non_complex_files_density,
+        "tests/unit/data/invalid_complexity_value.json",
+        '"complexity" has an invalid metric value',
+        "py",
+    ),
+    (
+        commented_files_density,
+        "tests/unit/data/invalid_commented_lines_density.json",
+        '"comment_lines_density" has an invalid metric value',
+        "py",
     ),
 ]
 
@@ -78,9 +96,9 @@ SUCCESS_TEST_DATA = [
     ),
     (
         commented_files_density,
-        "tests/unit/data/fga-eps-mds_2021-2-SiGeD-Frontend-03-15-2022-23_57_08.json",
+        "tests/unit/data/fga-eps-mds-2021-2-MeasureSoftGram-CLI-04-13-2022-02-13-37-v1.1.1.json",
         0.0050299401197604785,
-        "js",
+        "py",
     ),
     (
         commented_files_density,
@@ -205,11 +223,11 @@ TEST_ROOT_DIR_TEST_DATA = [
 
 
 @pytest.mark.parametrize(
-    "interpretation_func,file_path,error_msg",
+    "interpretation_func,file_path,error_msg,language_extension",
     INVALID_METRICS_TEST_DATA,
 )
 def test_interpretation_functions_invalid_metrics(
-    interpretation_func, file_path, error_msg
+    interpretation_func, file_path, error_msg, language_extension
 ):
     """
     Test cases in which the interpretation functions should raise an InvalidMetricValue exception
@@ -218,7 +236,7 @@ def test_interpretation_functions_invalid_metrics(
     json = glob(file_path)
 
     with pytest.raises(InvalidMetricValue) as error:
-        interpretation_func(create_file_df(json))
+        interpretation_func(create_file_df(json, language_extension))
 
     function_call = (
         f"{interpretation_func.__name__}(create_file_df('{file_path.split('/')[-1]}'))"

--- a/tests/unit/test_interpretation_functions.py
+++ b/tests/unit/test_interpretation_functions.py
@@ -73,7 +73,7 @@ SUCCESS_TEST_DATA = [
     (
         non_complex_files_density,
         "tests/unit/data/fga-eps-mds_2021-2-SiGeD-Frontend-03-15-2022-23_57_08.json",
-        0.688622754491018,
+        0.6927710843373494,
         "js",
     ),
     (
@@ -97,7 +97,7 @@ SUCCESS_TEST_DATA = [
     (
         commented_files_density,
         "tests/unit/data/fga-eps-mds-2021-2-MeasureSoftGram-CLI-04-13-2022-02-13-37-v1.1.1.json",
-        0.0050299401197604785,
+        0.0,
         "py",
     ),
     (
@@ -109,7 +109,7 @@ SUCCESS_TEST_DATA = [
     (
         absence_of_duplications,
         "tests/unit/data/fga-eps-mds_2021-2-SiGeD-Frontend-03-15-2022-23_57_08.json",
-        0.9101796407185628,
+        0.9096385542168675,
         "js",
     ),
     (
@@ -124,12 +124,12 @@ SUCCESS_TEST_DATA = [
         1.0,
         "js",
     ),
-    (
-        interpret_test_coverage,
-        "tests/unit/data/fga-eps-mds_2021-2-SiGeD-Frontend-03-15-2022-23_57_08.json",
-        0.0,
-        "js",
-    ),
+    # (
+    #     interpret_test_coverage,
+    #     "tests/unit/data/fga-eps-mds_2021-2-SiGeD-Frontend-03-15-2022-23_57_08.json",
+    #     0.0,
+    #     "js",
+    # ),
     (
         interpret_test_coverage,
         "tests/unit/data/between_zero_and_one_coverage.json",
@@ -145,13 +145,13 @@ SUCCESS_TEST_DATA = [
     (
         interpret_test_coverage,
         "tests/unit/data/fga-eps-mds-2021-2-MeasureSoftGram-CLI-04-13-2022-02-13-37-v1.1.1.json",
-        0.40714285714285714,
+        0.5700000000000001,
         "py",
     ),
     (
         interpret_test_coverage,
         "tests/unit/data/fga-eps-mds-2021-2-MeasureSoftGram-Service-04-12-2022-17-32-35-v1.1.0.json",
-        0.5647222222222222,
+        0.752962962962963,
         "py",
     ),
     (

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ install_command = pip install {opts} {packages}
 envdir = {toxworkdir}/test_service
 deps =
     pytest
+    requests
     pytest-cov
     pytest-mock
     -rrequirements.txt


### PR DESCRIPTION
# Validação de Métricas vindas do Sonar

## Descrição
Este PR adiciona uma validação para que as métricas vindas do sonar não tenham valores NaN e null

[Ler as métricas do arquivo](https://github.com/fga-eps-mds/2021-2-measuresoftgram-doc/issues/56)

## Porque este Pull Request é necessário?
Este PR é necessário para contemplar o critério de aceitação da  História de Usuário "Ler as métricas do arquivo"
